### PR TITLE
Bind to the wide library

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ dependencies:
 
 2. Run `shards install`
 
-**NOTE**: You may need to install the ncurses development library `libncurses5-dev` (Debian)
+**NOTE**: You may need to install the wide ncurses development library `libncursesw5-dev` (Debian)
 
 ## Usage
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: ncurses
-version: 0.0.5
+version: 0.0.6
 
 authors:
   - Joakim Reinert <mail@jreinert.com>

--- a/src/lib_ncurses.cr
+++ b/src/lib_ncurses.cr
@@ -1,4 +1,4 @@
-@[Link("ncurses")]
+@[Link("ncursesw")]
 
 require "./lib_ncurses/*"
 

--- a/src/ncurses/version.cr
+++ b/src/ncurses/version.cr
@@ -1,3 +1,3 @@
 module NCurses
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
`ncursesw` should back-support methods from `ncurses` i.e. shouldn't break any functionality for those using this binding currently

I personally needed UTF-8 support and thought this could be useful for others. Disregard if not in the scope of this shard :)