### PR TITLE
Add "Default" to color enum. Add default color functions.

### DIFF
--- a/src/lib_ncurses.cr
+++ b/src/lib_ncurses.cr
@@ -11,6 +11,7 @@ lib LibNCurses
 
   # Used to color output by creating color pairs
   enum Color : LibC::Short
+    Default = -1
     Black   = 0
     Red     = 1
     Green   = 2
@@ -104,6 +105,8 @@ lib LibNCurses
   fun wattrset(window : Window, attr : Attribute) : LibC::Int
 
   # Color functions
+  fun use_default_colors : LibC::Int
+  fun assume_default_colors(fg : LibC::Int, bg : LibC::Int) : LibC::Int
   fun start_color : LibC::Int
   fun has_colors : Bool
   fun can_change_color : Bool

--- a/src/ncurses.cr
+++ b/src/ncurses.cr
@@ -188,6 +188,14 @@ module NCurses
   # ## Color
   #
 
+  def use_default_colors
+    raise "use_default_colors error" if LibNCurses.use_default_colors == ERR
+  end
+
+  def assume_default_colors(fg, bg)
+    raise "assume_default_colors error" if LibNCurses.assume_default_colors(fg, bg) == ERR
+  end
+
   # Start color support
   # Wrapper for `start_color()`
   def start_color


### PR DESCRIPTION
These are necessary to retain terminal transparency while still using color pairs.

In the Ncurses C library, the "default" color of a terminal (whether it's foreground or background) is defined as -1. I've added a `Default = -1` entry to the `NCursesLib::Colors` enum. I've also added the two functions necessary to use it: `use_default_colors` and `assume_default_colors`.

Either `use_default_colors` or `assume_default_colors` *must* be called before using the `Colors::Default` member. `assume_default_colors` is a refinement of `use_default_colors` that tells Ncurses what to use as a default color.