### PR TITLE
Wrap the def_prog_mode and reset_prog_mode functions

### DIFF
--- a/src/lib_ncurses.cr
+++ b/src/lib_ncurses.cr
@@ -32,6 +32,8 @@ lib LibNCurses
   fun initscr : Window
   fun endwin : LibC::Int
   fun curs_set(visibility : LibC::Int) : LibC::Int
+  fun def_prog_mode
+  fun reset_prog_mode
 
   # General window functions
   fun newwin(height : LibC::Int, width : LibC::Int, row : LibC::Int, col : LibC::Int) : Window

--- a/src/ncurses.cr
+++ b/src/ncurses.cr
@@ -60,6 +60,16 @@ module NCurses
     LibNCurses.curs_set(visibility) != ERR
   end
 
+  # Save the tty mode
+  def def_prog_mode
+    LibNCurses.def_prog_mode
+  end
+
+  # Restore the tty mode
+  def reset_prog_mode
+    LibNCurses.reset_prog_mode
+  end
+
   # Get stdscr
   # May remove due to delegateing
   def stdscr


### PR DESCRIPTION
These functions are required to "suspend/resume" an ncurses program. An example program with the C library (taken from [tldp.org](https://tldp.org/HOWTO/NCURSES-Programming-HOWTO/misc.html)) looks like this:

```c
#include <ncurses.h>

int main()
{	
	initscr();			            /* Start curses mode 		           */
	printw("Hello World !!!\n");	/* Print Hello World		           */
	refresh();			            /* Print it on to the real screen      */
	def_prog_mode();	            /* Save the tty modes		           */
	endwin();			            /* End curses mode temporarily	       */
	system("/bin/sh");		        /* Do whatever you like in cooked mode */
	reset_prog_mode();		        /* Return to the previous tty mode     */
					                /* stored by def_prog_mode() 	       */
	refresh();			            /* Do refresh() to restore the	       */
					                /* Screen contents		               */
	printw("Another String\n");	    /* Back to curses use the full         */
	refresh();			            /* capabilities of curses	           */
	endwin();			            /* End curses mode		               */

	return 0;
}
```