### PR TITLE
Add potential keycode for backspace keypress

### DIFF
--- a/src/lib_ncurses/key.cr
+++ b/src/lib_ncurses/key.cr
@@ -24,6 +24,8 @@ lib LibNCurses
     # KEY_BACKSPACE
     Backspace = 0o407
 
+    Erase = 0o177
+
     # F0 to F63
     {% for n in (0...64) %}
       F{{n}} = 0o410 + {{n}}


### PR DESCRIPTION
I was running into some weirdness while running the input example where pressing `Backspace` on my keyboard resulted in `^?` being printed. After doing some digging, I found that the value in `key.cr` is `0o047` which is truly the ASCII control code for backspace and I can get `Backspace` to print in the example with `Ctrl + H` on my keyboard.

After further reading, I realized the terminal is getting the ASCII control code for delete (`0o117`) when I press `Backspace` on my keyboard. This is common on modern systems as noted [here](https://en.wikipedia.org/wiki/Backspace#Common_use). Since there is already a `Delete` in `key.cr` (the "del" key on the keyboard), I added `Erase` since some keyboards have that label on the backspace key.

You can see the control codes and their corresponding values [here](https://en.wikipedia.org/wiki/ASCII#Control_code_chart)