### PR TITLE
Support to raw 256 X-term-colors by adding init_color_pair function a UInt8 orverload

### DIFF
--- a/examples/colors.cr
+++ b/examples/colors.cr
@@ -16,6 +16,7 @@ NCurses.init_color_pair(1, NCurses::Color::Red, NCurses::Color::Green)
 NCurses.init_color_pair(2, NCurses::Color::Blue, NCurses::Color::Black)
 NCurses.init_color_pair(3, NCurses::Color::Black, NCurses::Color::White)
 NCurses.init_color_pair(4, NCurses::Color::Cyan, NCurses::Color::Magenta)
+NCurses.init_color_pair(5, 208, 0)
 
 # Change color RGB values if terminal supports it
 if NCurses.can_change_color?
@@ -41,6 +42,11 @@ NCurses.set_color 4
 
 NCurses.print "\nThis should appear to be white on black\n"
 NCurses.print "But color pair 4 is cyan on magenta\n"
+
+NCurses.set_color 5
+
+NCurses.print "\nAnd you can pass raw X-term colors\n"
+NCurses.print "This is a orange text"
 
 NCurses.set_color
 

--- a/src/ncurses.cr
+++ b/src/ncurses.cr
@@ -245,7 +245,7 @@ module NCurses
   # init_color_pair 5, Color::Red, Color::Blue # => Color pair 5 is not red on black
   # ```
   # Wrapper for `init_pair()`
-  def init_color_pair(slot, foreground : Color, background : Color)
+  def init_color_pair(slot, foreground : (Color | UInt8), background : (Color| UInt8))
     raise "init_pair error" if LibNCurses.init_pair(slot.to_i16, foreground.to_i16, background.to_i16) == ERR
   end
 


### PR DESCRIPTION
Hello as I pointed in #21 issue I'm having trouble with colors in a 256 X-term-color terminal, here are some small modifications, that allow use UInt8 values for `init_color_pair` directly. If you analyze, and think the changes are good this pull request is already made 😀 and if not I await yours ideas in the issue