### PR TITLE
Implement `subwin` and `derwin`

### DIFF
--- a/examples/windows.cr
+++ b/examples/windows.cr
@@ -15,7 +15,9 @@ right.print "Right side!\n"
 right.print "Width: #{right.width}\n"
 right.print "Height: #{right.height}\n"
 
-left.print "\nPress q to quit\n"
+message = left.derwin(3, left.width, left.height - 3, 0)
+message.box
+message.print "Press q to quit", 1, 1
 
 left.refresh
 right.refresh

--- a/src/lib_ncurses.cr
+++ b/src/lib_ncurses.cr
@@ -38,6 +38,8 @@ lib LibNCurses
 
   # General window functions
   fun newwin(height : LibC::Int, width : LibC::Int, row : LibC::Int, col : LibC::Int) : Window
+  fun derwin(window : Window, height : LibC::Int, width : LibC::Int, row : LibC::Int, col : LibC::Int) : Window
+  fun subwin(window : Window, height : LibC::Int, width : LibC::Int, row : LibC::Int, col : LibC::Int) : Window
   fun delwin(window : Window) : LibC::Int
   fun mvwin(window : Window, y : LibC::Int, x : LibC::Int) : LibC::Int
   fun getcury(window : Window) : LibC::Int

--- a/src/ncurses/window.cr
+++ b/src/ncurses/window.cr
@@ -14,6 +14,22 @@ module NCurses
       initialize(LibNCurses.newwin(height || max_height, width || max_width, y, x))
     end
 
+    # Creates a new subwindow with given size and position. The position is relative to the screen.
+    # The subwindow shares memory with the parent window, so changes and refreshes apply to both.
+    # Its main use case is avoiding to calculate offsets when printing.
+    #
+    # Wrapper for `subwin()`
+    def subwin(height, width, y, x)
+      Window.new(LibNCurses.subwin(self, height, width, y, x))
+    end
+
+    # Like `subwin`, but the position is relative to the parent window.
+    #
+    # Wrapper for `derwin()`
+    def derwin(height, width, y, x)
+      Window.new(LibNCurses.derwin(self, height, width, y, x))
+    end
+
     # Delete the window
     #
     # Wrapper for `delwin()`


### PR DESCRIPTION
In other parts of the library, there is some mapping between the C function names, and some more legible ones but I couldn't think of good ones here (`sub_window` and `derived_window`?) so I decided to keep the C NCurses ones.

I also thought if there could be some sensible defaults (like `Window.new` has), but the only ones that _could_ make sense (default to the whole width and height of the parent window, and set x, y to 0, 0) don't really make sense for subwindows (what would be the use case for that, you'd just have two `Window`s where you can write to the exact same effect), so again I left it without defaults.

Also changed the windows example to use `derwin`